### PR TITLE
adding env var to modify the stage name

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -24,7 +24,7 @@ custom:
 provider:
   name: aws
   runtime: nodejs4.3
-  stage: dev
+  stage: ${env:ENV_TYPE}
   region: ap-southeast-2
   environment:
     APP_NAME: ${self:service}


### PR DESCRIPTION
This will allow the serverless to deploy dynamically with the stage set to ENV_TYPE env var.

We can set the Codebuild to pass the ENV_TYPE dynamically during build.